### PR TITLE
Moved obtaining inputs into get_info, rather than being automatically stored on the leader.

### DIFF
--- a/Manual/content/changelog.html
+++ b/Manual/content/changelog.html
@@ -40,6 +40,9 @@
       <li><span class="cl-c">Added</span> the ability for a sector to reuse the same vertex. Before, it just considered the sector broken.</li>
       <li><span class="cl-c">Added</span> the ability to create sub-sectors. This happens if one sector's polygon ends up getting split into two. While not recommended, it stops the maker from receiving warnings and from the sector to be considered broken.</li>
       <li><span class="cl-c">Added</span> the ability to keep drawing a new sector, for when you try to split a sector but the engine considers that split useless.</li>
+      <li><span class="cl-a">Added</span> three new controls: <code>custom_a</code>, <code>custom_b</code> and <code>custom_c</code>. These do nothing on their own, but can be detected through <a href="mob_leader.html">leader</a> scripts. (Thanks WanderingLetterS)</li>
+      <li><span class="cl-a">Added</span> the <code>on_input_received</code> <a href="events_and_actions.html">object script event</a>.</li>
+      <li><span class="cl-a">Added</span> the <code>input_name</code> and <code>input_value</code> properties to the <code>get_info</code> <a href="events_and_actions.html">object script action</a>.</li>
     </ul>
 
     <h2 id="0.24.0">0.24.0</h2>

--- a/Manual/content/events_and_actions.html
+++ b/Manual/content/events_and_actions.html
@@ -172,6 +172,10 @@
         <th style="text-align: left;"><code>on_weight_removed</code></th>
         <td>Triggered when an object that was standing atop this one leaves, thus removing weight.</td>
       </tr>
+       <tr>
+        <th style="text-align: left;"><code>on_input_received</code></th>
+        <td>Triggered when an action key is pressed. The action and value can be obtained with the <code>get_info</code> action. This event is only run on the currently active <a href="mob_leader.html">leader</a>.</td>
+      </tr>
     </table>
     
     <h2 id="actions">Actions</h2>
@@ -598,6 +602,8 @@
               <li><code><b>hazard</b></code>: Name of the hazard that the object has touched or left.</li>
               <li><code><b>health</b></code>: The object's current health.</li>
               <li><code><b>health_ratio</b></code>: The object's current health ratio. 0 for 0%, 1 for 100%, 0.5 for 50%, etc.</li>
+              <li><code><b>input_name</b></code>: The name of the input that triggered an <code>on_input_received</code> event.</li>
+              <li><code><b>input_value</b></code>: The value of the input that triggered an <code>on_input_received</code> event. 1 when fully pressed, 0 when fully released.</li>
               <li><code><b>latched_pikmin</b></code>: How many Pikmin are currently latched on to it.</li>
               <li><code><b>latched_pikmin_weight</b></code>: Total weight of the Pikmin that are currently latched on to it.</li>
               <li><code><b>message</b></code>: What the message was that got sent when the <code>on_receive_message</code> event got triggered.</li>

--- a/Source/source/game_states/gameplay/control_handling.cpp
+++ b/Source/source/game_states/gameplay/control_handling.cpp
@@ -27,7 +27,7 @@ void gameplay_state::handle_player_action(const player_action &action) {
 
     //Before we do the actions, we'll tell the Leader object it's recieved an input, which will trigger an event.
     if(cur_leader_ptr) {
-        cur_leader_ptr->fsm.run_event(MOB_EV_INPUT_RECIEVED,
+        cur_leader_ptr->fsm.run_event(MOB_EV_INPUT_RECEIVED,
             (void*)&action
         );
     }

--- a/Source/source/game_states/gameplay/control_handling.cpp
+++ b/Source/source/game_states/gameplay/control_handling.cpp
@@ -22,24 +22,19 @@ void gameplay_state::handle_player_action(const player_action &action) {
 
     if(!ready_for_input || !is_input_allowed) return;
     if(cur_interlude != INTERLUDE_NONE) return;
-    
-
 
     bool is_down = (action.value >= 0.5);
 
     //Before we do the actions, we'll tell the Leader object it's recieved an input, which will trigger an event.
-    if (cur_leader_ptr) {
-        string recieved_input;
-        recieved_input = game.controls.internal_name_from_id(action.action_type_id);
-        if (!is_down) recieved_input += "_released";
-        cur_leader_ptr->set_var("recieved_input", recieved_input);
-        cur_leader_ptr->fsm.run_event(MOB_EV_INPUT_RECIEVED);
+    if(cur_leader_ptr) {
+        cur_leader_ptr->fsm.run_event(MOB_EV_INPUT_RECIEVED,
+            (void*)&action
+        );
     }
-    
 
     if(!msg_box && !onion_menu && !pause_menu) {
-    
-        switch (action.action_type_id) {
+
+        switch(action.action_type_id) {
         case PLAYER_ACTION_THROW: {
 
             /*******************
@@ -48,7 +43,7 @@ void gameplay_state::handle_player_action(const player_action &action) {
             *           &      *
             *******************/
 
-            if (is_down) { //Button press.
+            if(is_down) { //Button press.
 
                 bool done = false;
 

--- a/Source/source/mob_script.cpp
+++ b/Source/source/mob_script.cpp
@@ -185,7 +185,7 @@ mob_event::mob_event(data_node* node, const vector<mob_action_call*> &actions) :
     r("on_touch_wall",                  MOB_EV_TOUCHED_WALL);
     r("on_weight_added",                MOB_EV_WEIGHT_ADDED);
     r("on_weight_removed",              MOB_EV_WEIGHT_REMOVED);
-    r("on_input_recieved",              MOB_EV_INPUT_RECIEVED);
+    r("on_input_received",              MOB_EV_INPUT_RECEIVED);
 
     else {
         type = MOB_EV_UNKNOWN;

--- a/Source/source/mob_script.h
+++ b/Source/source/mob_script.h
@@ -109,7 +109,7 @@ enum MOB_EV_TYPES {
     //When weight was removed from on top of it. Only if this mob's walkable.
     MOB_EV_WEIGHT_REMOVED,
     //When the player sends an Input
-    MOB_EV_INPUT_RECIEVED,
+    MOB_EV_INPUT_RECEIVED,
 
 
     //More internal script stuff.

--- a/Source/source/mob_script_action.cpp
+++ b/Source/source/mob_script_action.cpp
@@ -2247,13 +2247,13 @@ void get_info_runner(mob_action_run_data &data, mob* target_mob) {
         break;
         
     } case MOB_ACTION_GET_INFO_INPUT_NAME: {
-        if(data.call->parent_event == MOB_EV_INPUT_RECIEVED) {
+        if(data.call->parent_event == MOB_EV_INPUT_RECEIVED) {
             *var = game.controls.internal_name_from_id(((player_action*)(data.custom_data_1))->action_type_id);
         }
         break;
 
     } case MOB_ACTION_GET_INFO_INPUT_VALUE: {
-        if (data.call->parent_event == MOB_EV_INPUT_RECIEVED) {
+        if (data.call->parent_event == MOB_EV_INPUT_RECEIVED) {
             *var = f2s(((player_action*)(data.custom_data_1))->value);
         }
         break;

--- a/Source/source/mob_script_action.cpp
+++ b/Source/source/mob_script_action.cpp
@@ -326,6 +326,10 @@ bool mob_action_loaders::get_info(mob_action_call &call) {
         call.args[1] = i2s(MOB_ACTION_GET_INFO_HEALTH);
     } else if(call.args[1] == "health_ratio") {
         call.args[1] = i2s(MOB_ACTION_GET_INFO_HEALTH_RATIO);
+    } else if (call.args[1] == "input_name") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_INPUT_NAME);
+    } else if (call.args[1] == "input_value") {
+        call.args[1] = i2s(MOB_ACTION_GET_INFO_INPUT_VALUE);
     } else if(call.args[1] == "latched_pikmin") {
         call.args[1] = i2s(MOB_ACTION_GET_INFO_LATCHED_PIKMIN);
     } else if(call.args[1] == "latched_pikmin_weight") {
@@ -2242,6 +2246,18 @@ void get_info_runner(mob_action_run_data &data, mob* target_mob) {
         *var = f2s(target_mob->health / target_mob->max_health);
         break;
         
+    } case MOB_ACTION_GET_INFO_INPUT_NAME: {
+        if(data.call->parent_event == MOB_EV_INPUT_RECIEVED) {
+            *var = game.controls.internal_name_from_id(((player_action*)(data.custom_data_1))->action_type_id);
+        }
+        break;
+
+    } case MOB_ACTION_GET_INFO_INPUT_VALUE: {
+        if (data.call->parent_event == MOB_EV_INPUT_RECIEVED) {
+            *var = f2s(((player_action*)(data.custom_data_1))->value);
+        }
+        break;
+
     } case MOB_ACTION_GET_INFO_LATCHED_PIKMIN: {
         *var = i2s(target_mob->get_latched_pikmin_amount());
         break;

--- a/Source/source/mob_script_action.h
+++ b/Source/source/mob_script_action.h
@@ -268,6 +268,10 @@ enum MOB_ACTION_GET_INFO_TYPES {
     MOB_ACTION_GET_INFO_HEALTH_RATIO,
     //Get amount of latched Pikmin.
     MOB_ACTION_GET_INFO_LATCHED_PIKMIN,
+    //Get the name of the input that triggered the event.
+    MOB_ACTION_GET_INFO_INPUT_NAME,
+    //Get the value of the input that triggered the event.
+    MOB_ACTION_GET_INFO_INPUT_VALUE,
     //Get total weight of latched Pikmin.
     MOB_ACTION_GET_INFO_LATCHED_PIKMIN_WEIGHT,
     //Get message that triggered the event.


### PR DESCRIPTION
This puts obtaining input information more in line with obtaining other information.